### PR TITLE
fix(tooling): correct the documented Dart format scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,7 +270,7 @@ If you later split CI into parallel jobs for speed, you can require each job or 
 - Follow [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style)
 - Use `very_good_analysis` linting rules (already configured)
 - Run `flutter analyze` before committing
-- Format Dart sources (not the whole repo — skips `build/`): `./scripts/dev/format_dart.sh` or `dart format lib test integration_test tool bricks`
+- Format Dart sources (not the whole repo — skips `build/`): `./scripts/dev/format_dart.sh` or `dart format lib test integration_test tool examples`
 
 ### Architecture
 

--- a/docs/guides/support/troubleshooting.md
+++ b/docs/guides/support/troubleshooting.md
@@ -27,7 +27,7 @@ If you are stuck after that, check the sections below by symptom (build/codegen/
 flutter clean   # optional but clears a bad build/ tree
 ./scripts/dev/format_dart.sh
 # or explicitly:
-dart format lib test integration_test tool bricks
+dart format lib test integration_test tool examples
 ```
 
 CI and git hooks use the scoped paths above, not the whole repo root.

--- a/docs/guides/testing/testing-summary.md
+++ b/docs/guides/testing/testing-summary.md
@@ -13,7 +13,7 @@ Run the same gates CI uses for Dart code (no Android/iOS/Web builds):
 Or step by step:
 
 ```bash
-./scripts/dev/format_dart.sh --check   # or: dart format --set-exit-if-changed lib test integration_test tool bricks
+./scripts/dev/format_dart.sh --check   # or: dart format --set-exit-if-changed lib test integration_test tool examples
 flutter analyze
 flutter test
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ Shell utilities grouped by purpose. **Platform folders** (`android/`, `ios/`, â€
 
 | Script | Purpose |
 |--------|---------|
-| [`format_dart.sh`](dev/format_dart.sh) | Format only `lib`, `test`, `integration_test`, `tool`, `bricks` (avoids scanning `build/`). Use `--check` for CI-style verification. |
+| [`format_dart.sh`](dev/format_dart.sh) | Format only `lib`, `test`, `integration_test`, `tool`, `examples` (avoids scanning `build/`). Use `--check` for CI-style verification, or `--print-paths` to read the scope. Not `bricks/`: it holds Mason templates whose mustache is not valid Dart, so `dart format` exits 65 on it. |
 | [`audit_template.sh`](dev/audit_template.sh) | Full non-platform gate: format check, `flutter analyze`, `flutter test`. |
 | [`setup_git_hooks.sh`](dev/setup_git_hooks.sh) | Copy `.githooks/*` â†’ `.git/hooks/` (single source of truth in repo). |
 | [`setup_branding.sh`](dev/setup_branding.sh) | Splash / launcher assets (see root README). |

--- a/scripts/dev/audit_template.sh
+++ b/scripts/dev/audit_template.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$ROOT"
-echo "==> format (lib test integration_test tool bricks)"
+echo "==> format ($("$SCRIPT_DIR/format_dart.sh" --print-paths))"
 "$SCRIPT_DIR/format_dart.sh" --check
 echo "==> flutter analyze"
 flutter analyze

--- a/scripts/dev/format_dart.sh
+++ b/scripts/dev/format_dart.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 # Formats only project Dart sources (not `build/`, `.dart_tool/`, etc.).
 # Usage:
-#   ./scripts/dev/format_dart.sh          # write changes
-#   ./scripts/dev/format_dart.sh --check # CI-style; exit 1 if reformat needed
+#   ./scripts/dev/format_dart.sh              # write changes
+#   ./scripts/dev/format_dart.sh --check      # CI-style; exit 1 if reformat needed
+#   ./scripts/dev/format_dart.sh --print-paths # echo the scope, for other scripts
+#
+# `paths` below is the single source of truth for the format scope and must stay
+# in step with the "Verify formatting" step in .github/workflows/ci.yml. Anything
+# that needs to name the scope should call --print-paths rather than retyping it:
+# retyped copies drifted to a wrong value once already (see issue #8).
+#
+# `bricks` is deliberately NOT in scope: bricks/**/__brick__/** holds Mason
+# templates containing mustache, which is not valid Dart, so `dart format` exits
+# 65 on it. analysis_options.yaml excludes it for the same reason.
 set -euo pipefail
 paths=(lib test integration_test tool examples)
+if [[ "${1:-}" == "--print-paths" ]]; then
+  echo "${paths[*]}"
+  exit 0
+fi
 if [[ "${1:-}" == "--check" ]]; then
   dart format --set-exit-if-changed "${paths[@]}"
 else


### PR DESCRIPTION
Five places told contributors the format scope was `lib test integration_test
tool bricks`. The real scope, defined once in `scripts/dev/format_dart.sh`, is
`lib test integration_test tool examples`.

`bricks` was not just a stale name - it broke the command. `bricks/**/__brick__/**`
holds Mason templates containing mustache (`{{feature_name}}`), which is not
valid Dart:

```
$ dart format --set-exit-if-changed bricks                                    # exit 65
$ dart format --set-exit-if-changed lib test integration_test tool examples    # exit 0
```

So anyone copying the command out of `CONTRIBUTING.md` got a syntax error, and
`analysis_options.yaml` already excludes `bricks/**/__brick__/**` for the same
reason.

## Fixing the class, not the instance

The worst site was `scripts/dev/audit_template.sh`, which **printed** the wrong
scope one line above delegating to the script that had the right one. Rather
than retype the correct value a fifth time, the announced scope is now derived:

```bash
echo "==> format ($("$SCRIPT_DIR/format_dart.sh" --print-paths))"
```

`format_dart.sh` gains a `--print-paths` mode for that. Its `paths=` array and
default behavior are untouched, so the scope still matches the "Verify
formatting" step in `ci.yml` (issue #8 criterion 5).

## Sites corrected

| File | Was |
|---|---|
| `scripts/dev/audit_template.sh` | hardcoded `tool bricks` echo -> now derived |
| `scripts/README.md` | claimed `format_dart.sh` formats `bricks` |
| `CONTRIBUTING.md` | `dart format ... tool bricks` |
| `docs/guides/testing/testing-summary.md` | same |
| `docs/guides/support/troubleshooting.md` | same |

`scripts/README.md` now also states why `bricks/` is excluded, so the next
person does not "helpfully" add it back.

Refs koniz-dev/flutter-starter#8