### PR TITLE
docs(contributing): link issues with Refs, never Closes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,14 @@ Users prefer dark mode for better battery life and eye comfort, especially in lo
 
 ### Pull Requests
 
-Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests.
+
+> Issues are the single source of truth for what gets worked on, in what order,
+> and when it counts as done. Before picking something up, read
+> [docs/issue-workflow.md](docs/issue-workflow.md) — it defines the label state
+> machine, the acceptance-criteria requirement, and why commits link to issues
+> rather than closing them.
+
 
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
@@ -136,7 +143,7 @@ Before submitting a PR, make sure:
 - [ ] Documentation is updated (if needed)
 - [ ] Commit messages follow the guidelines
 - [ ] PR description is clear and descriptive
-- [ ] Related issues are referenced (if any)
+- [ ] Related issues are referenced with `Refs owner/repo#N` (never `Closes`/`Fixes`/`Resolves`)
 
 ---
 
@@ -362,7 +369,14 @@ test(auth): add login use case tests
 - Keep subject line under 50 characters
 - Capitalize first letter of subject
 - No period at end of subject
-- Reference issues in footer: `Closes #123`
+- Reference issues in the footer as `Refs koniz-dev/flutter-starter#123`
+
+> **Do not use `Closes`, `Fixes`, or `Resolves`.** GitHub auto-closes an issue
+> when a commit carrying those keywords lands on the default branch. That closes
+> it at *merge* time, before anyone has run its acceptance criteria — which
+> removes the verification gate the workflow exists to enforce. Use the fully
+> qualified `owner/repo#N` form so the reference survives being quoted elsewhere.
+> See [docs/issue-workflow.md](docs/issue-workflow.md).
 
 ---
 


### PR DESCRIPTION
`CONTRIBUTING.md` told contributors to write `Closes #123` in a commit footer -
directly contradicting invariant 3 of the issue workflow, which bans auto-close
keywords.

Not a style preference. GitHub auto-closes an issue when a commit carrying
`Closes`/`Fixes`/`Resolves` lands on the default branch, so the issue closes at
**merge** time, before anything has run its `## Acceptance criteria`. That
removes the verification gate the whole workflow exists to enforce. An autonomous
session following `CONTRIBUTING.md` would have defeated it on its first commit.

## Changes

1. The guideline now says `Refs koniz-dev/flutter-starter#123` **and states why**
   the auto-close keywords are banned - so the next person does not restore them
   as a convenience.
2. The PR checklist said only "Related issues are referenced (if any)", which was
   compatible with either convention. It now names `Refs` explicitly.
3. The Pull Requests section links `docs/issue-workflow.md`, making the rule
   reachable from the contribution entry point rather than only from a document a
   contributor might never open.

## Note on checks

This PR touches only `CONTRIBUTING.md`. `ci.yml` has `paths-ignore` for
`**/*.md`, so it will report **no checks at all** - expected, not a failure.

Refs koniz-dev/flutter-starter#10