### PR TITLE
fix(testing): document the three UiKeys no widget attaches

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -29,7 +29,11 @@ patrol test --target integration_test/app_e2e_test.dart
 
 Do not rely on translated button labels for critical steps. Use `ValueKey`s from [`lib/core/constants/ui_keys.dart`](../lib/core/constants/ui_keys.dart) (e.g. `e2e_login_submit`, `e2e_home_content`).
 
-**Full starter:** `app_e2e_test.dart` may also use tasks keys (`e2e_open_tasks`, `e2e_tasks_fab`, …). **After** `dart run tool/strip_sample_features.dart --apply`, golden files rewrite E2E to **auth → home** only; keep tests in sync if you maintain a fork without running strip.
+`app_e2e_test.dart` covers **auth → home** and nothing else, in the full starter as well as after a strip. It asserts only `e2e_login_submit` and `e2e_home_content`.
+
+**There is no tasks coverage, on purpose.** `UiKeys.openTasks`, `UiKeys.tasksFab`, and `UiKeys.addTaskSubmit` are declared but attached to no widget in `lib/`: `HomeScreen` is a deliberately minimal shell with no entry point into the sample `tasks` feature. Patrol matches on the widget tree, so a selector written against an unattached key finds nothing — attach the key first if your fork adds that entry point. `tool/golden/no_feature_flags/` shows the wiring, and its own `app_e2e_test.dart` does drive the full tasks flow.
+
+**After** `dart run tool/strip_sample_features.dart --apply`, golden files replace these E2E files outright, so the post-strip variant is whatever `tool/golden/<variant>/integration_test/` contains — editing the copies here does not affect it.
 
 ## CI
 

--- a/integration_test/app_e2e_test.dart
+++ b/integration_test/app_e2e_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 
 void main() {
-  patrolTest('E2E: Auth -> home (stripped starter; stable ValueKeys)', (
+  patrolTest('E2E: auth -> home (stable ValueKeys)', (
     $,
   ) async {
     app.main();

--- a/lib/core/constants/ui_keys.dart
+++ b/lib/core/constants/ui_keys.dart
@@ -15,12 +15,30 @@ abstract final class UiKeys {
   /// Home body after authentication (works for full and stripped home UIs).
   static const homeContent = ValueKey<String>('e2e_home_content');
 
-  /// Navigates from home to the tasks list (sample app entry point).
+  // The three keys below are NOT attached to any widget in this starter's
+  // default `lib/`. `HomeScreen` is deliberately a minimal shell ("extend per
+  // product"), so it offers no entry point into the sample `tasks` feature, and
+  // the tasks screens do not key their controls.
+  //
+  // They are kept because they are the agreed selector names for a fork that
+  // does add a tasks entry point, and because
+  // `tool/golden/no_feature_flags/` wires `openTasks` in its own `HomeScreen`.
+  // A fork must attach the key before writing a selector against it: Patrol
+  // matches on the widget tree, so an unattached key silently finds nothing.
+
+  /// Navigates from home to the tasks list.
+  ///
+  /// Intentionally unattached in the default starter - see the note above.
+  /// Attach to your own home-to-tasks control when you add one.
   static const openTasks = ValueKey<String>('e2e_open_tasks');
 
   /// Tasks list FAB to add a task.
+  ///
+  /// Intentionally unattached in the default starter - see the note above.
   static const tasksFab = ValueKey<String>('e2e_tasks_fab');
 
-  /// Confirms create-task dialog (label is l10n-dependent; key is stable).
+  /// Confirms the create-task dialog (label is l10n-dependent; key is stable).
+  ///
+  /// Intentionally unattached in the default starter - see the note above.
   static const addTaskSubmit = ValueKey<String>('e2e_add_task_submit');
 }


### PR DESCRIPTION
`UiKeys.openTasks`, `tasksFab`, and `addTaskSubmit` were declared but attached to
no widget in `lib/`. Patrol matches on the widget tree, so a fork writing a
selector against them would **silently find nothing** - the worst kind of test
failure.

## The decision this issue left open

#9 deliberately left the choice between (a) wiring the keys into the full
`HomeScreen` and extending E2E to cover tasks, or (b) documenting them as
provided-for-forks.

**Took (b).** `HomeScreen` is declared `minimal shell; extend per product`, so
adding a tasks entry point to the default starter changes product behavior the
author kept deliberately minimal - that is a product call, not a test-hygiene
fix. The keys stay because they are the agreed selector names for a fork that
does add one, and `tool/golden/no_feature_flags/` already wires `openTasks` in
its own `HomeScreen` and drives the full tasks flow in its own E2E.

If you would rather have (a), say so and I will reopen - the reverse change is
small, but it is yours to make, not mine.

## Two false claims corrected

- `integration_test/README.md` said *"Full starter: `app_e2e_test.dart` may also
  use tasks keys"*. It does not, and never did - the file was byte-identical to
  `tool/golden/stripped/`. It now states there is no tasks coverage, why, and
  that strip **replaces** these files outright, so editing the copies here does
  not affect the post-strip variant.
- The `patrolTest` description said `"stripped starter"` while living in the full
  starter tree. The golden counterparts keep their own titles, which are accurate
  for the variants they become.

## Verification

Every key is now either attached or documented as intentionally unattached:

```
loginSubmit      attached: login_screen.dart
registerSubmit   attached: register_screen.dart
homeContent      attached: home_screen.dart
openTasks        documented as intentionally unattached
tasksFab         documented as intentionally unattached
addTaskSubmit    documented as intentionally unattached
```

`./scripts/dev/audit_template.sh` exits 0 (2232 passed). Criterion 4 (strip
leaves an analyzable tree) is covered by the **Strip + analyze + test** check on
this PR, which runs exactly that command in a clean environment.

Criterion 6 was conditional on adding tasks coverage. Path (b) adds none, so it
does not apply and nothing needs `status:needs-uat`.

Refs koniz-dev/flutter-starter#9