### PR TITLE
test(testing): acceptance evidence for #9; document the pr-checks race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,12 @@ make the loop worthless.
 - **Docs-only PRs get no Quality gate.** `ci.yml` has
   `paths-ignore: ['**/*.md', 'docs/**']`, so `gh pr checks` reports no checks
   rather than a pass. Expected; do not wait on it and do not call it a failure.
+  **But do not confuse that with the registration race:** run straight after
+  `gh pr create`, `gh pr checks` says "no checks reported" even for a PR that
+  will get them, because GitHub has not created them yet. Poll until
+  `gh pr checks --json name --jq 'length'` is non-zero before watching, and use
+  `gh pr diff --name-only` against `paths-ignore` to decide which case you are
+  in. Merging on the wrong reading skips the gate entirely.
 
 ### Evidence discipline
 

--- a/docs/issue-workflow.md
+++ b/docs/issue-workflow.md
@@ -308,8 +308,26 @@ One issue at a time. Each change stays small and revertible.
    Refs koniz-dev/flutter-starter#12"
    git push -u origin fix/short-description
    gh pr create --fill --body "Refs koniz-dev/flutter-starter#12"
+
+   # Wait for checks to REGISTER before watching them. Run immediately after
+   # `pr create`, `gh pr checks` reports "no checks reported on the ... branch"
+   # simply because GitHub has not created them yet - indistinguishable from a
+   # docs-only PR that will genuinely never get any. Merging on that reading
+   # skips the gate entirely.
+   for _ in 1 2 3 4 5 6; do
+     [[ "$(gh pr checks --json name --jq 'length' 2>/dev/null || echo 0)" -gt 0 ]] && break
+     sleep 10
+   done
    gh pr checks --watch
    gh pr merge --squash --delete-branch
+   ```
+
+   To tell the two cases apart, compare the changed files against `ci.yml`'s
+   `paths-ignore` (`**/*.md`, `docs/**`): if every changed path matches, no check
+   will ever appear and there is nothing to wait for.
+
+   ```bash
+   gh pr diff --name-only
    ```
 
 6. **Verify and close, or hand off.** Run the acceptance harness, open every

--- a/docs/verification/issue-9/analyze.log
+++ b/docs/verification/issue-9/analyze.log
@@ -1,0 +1,6 @@
+$ flutter analyze
+
+Upgrading analysis_options.yaml to exclude build and platform directories.
+Analyzing flutter-starter...                                    
+No issues found! (ran in 4.2s)
+exit: 0

--- a/docs/verification/issue-9/audit_template.log
+++ b/docs/verification/issue-9/audit_template.log
@@ -1,0 +1,13 @@
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:34 +2228 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should wrap content in RepaintBoundary
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:35 +2229 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should create HomeScreen widget
+01:35 +2230 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should display welcome message
+01:35 +2231 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should have app bar with title
+01:35 +2232 ~1: All tests passed!
+exit: 0

--- a/docs/verification/issue-9/criteria-2-3.txt
+++ b/docs/verification/issue-9/criteria-2-3.txt
@@ -1,0 +1,26 @@
+# Criterion 2: integration_test/README.md matches what app_e2e_test.dart asserts
+
+-- what the E2E actually asserts --
+13:    if ($(#e2e_login_submit).exists) {
+16:      await $(#e2e_login_submit).tap();
+20:    expect($(#e2e_home_content), findsOneWidget);
+
+-- what the README now says --
+## Stable selectors
+
+Do not rely on translated button labels for critical steps. Use `ValueKey`s from [`lib/core/constants/ui_keys.dart`](../lib/core/constants/ui_keys.dart) (e.g. `e2e_login_submit`, `e2e_home_content`).
+
+`app_e2e_test.dart` covers **auth → home** and nothing else, in the full starter as well as after a strip. It asserts only `e2e_login_submit` and `e2e_home_content`.
+
+**There is no tasks coverage, on purpose.** `UiKeys.openTasks`, `UiKeys.tasksFab`, and `UiKeys.addTaskSubmit` are declared but attached to no widget in `lib/`: `HomeScreen` is a deliberately minimal shell with no entry point into the sample `tasks` feature. Patrol matches on the widget tree, so a selector written against an unattached key finds nothing — attach the key first if your fork adds that entry point. `tool/golden/no_feature_flags/` shows the wiring, and its own `app_e2e_test.dart` does drive the full tasks flow.
+
+**After** `dart run tool/strip_sample_features.dart --apply`, golden files replace these E2E files outright, so the post-strip variant is whatever `tool/golden/<variant>/integration_test/` contains — editing the copies here does not affect it.
+
+## CI
+
+-- the removed false claim --
+  occurrences of 'may also use tasks keys': 0
+
+# Criterion 3: no 'stripped starter' in the full tree
+integration_test/app_e2e_test.dart:7:  patrolTest('E2E: auth -> home (stable ValueKeys)', (
+integration_test/auth_flow_test.dart:7:  patrolTest('auth flow: enters credentials and reaches home', ($) async {

--- a/docs/verification/issue-9/criterion-1-key-audit.txt
+++ b/docs/verification/issue-9/criterion-1-key-audit.txt
@@ -1,0 +1,8 @@
+# Criterion 1: every UiKeys entry is attached to a widget OR documented
+
+  loginSubmit      attached: lib/features/auth/presentation/screens/login_screen.dart
+  registerSubmit   attached: lib/features/auth/presentation/screens/register_screen.dart
+  homeContent      attached: lib/features/home/presentation/screens/home_screen.dart
+  openTasks        documented as intentionally unattached
+  tasksFab         documented as intentionally unattached
+  addTaskSubmit    documented as intentionally unattached

--- a/docs/verification/issue-9/criterion-4-strip-smoke.txt
+++ b/docs/verification/issue-9/criterion-4-strip-smoke.txt
@@ -1,0 +1,12 @@
+# Criterion 4: strip leaves an analyzable tree (Strip + analyze + test on PR #19)
+
+  Quality gate: SUCCESS
+  Strip + analyze + test: SUCCESS
+
+Runs exactly: dart run tool/strip_sample_features.dart --apply, then
+flutter pub get, flutter analyze, flutter test - per .github/workflows/strip-smoke.yml.
+
+No tool/golden/* counterpart needed updating: strip COPIES golden files over
+the root files (tool/strip_sample_features.dart:98 _copyGoldenFile), so the
+pre-strip content of integration_test/app_e2e_test.dart does not reach the
+post-strip tree. lib/core/constants/ui_keys.dart has no golden counterpart.

--- a/docs/verification/issue-9/format.log
+++ b/docs/verification/issue-9/format.log
@@ -1,0 +1,4 @@
+$ dart format --set-exit-if-changed lib test integration_test tool examples
+
+Formatted 333 files (0 changed) in 1.29 seconds.
+exit: 0

--- a/docs/verification/issue-9/tests.log
+++ b/docs/verification/issue-9/tests.log
@@ -1,0 +1,124 @@
+$ flutter test --timeout=5m --reporter compact
+
+00:03 +51: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Debug utilities should have printConfig method                                             
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+00:03 +78: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Edge Cases printConfig should not throw in debug mode                                      
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+
+[... 674 lines elided by scripts/test/run_acceptance.sh.
+     Full output is reproducible by re-running the command above. ...]
+
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:18 +2221 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use light theme by default                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:18 +2222 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should have dark theme configured                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:18 +2223 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure router correctly                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:19 +2224 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure localization delegates                                                                     
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:19 +2225 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure supported locales                                                                          
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:19 +2226 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use locale from provider                                                                             
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:19 +2227 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure text direction from provider                                                               
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:19 +2228 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should wrap content in RepaintBoundary                                                                      
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:19 +2232 ~1: 1 skipped test.                                                                                                                                                                        
+01:19 +2232 ~1: All other tests passed!                                                                                                                                                                
+exit: 0


### PR DESCRIPTION
Evidence for the five applicable criteria on #9.

## Also: a trap I hit twice

Running `gh pr checks` immediately after `gh pr create` reports:

```
no checks reported on the 'fix/document-unwired-ui-keys' branch
```

That is **byte-identical** to the legitimate docs-only case, where `ci.yml`'s
`paths-ignore` means no check will ever appear. It happened on both PR #18 and
PR #19 - both of which did get checks about 10 seconds later, and both of which
passed.

A session that reads the race as the docs-only case merges **with no gate at
all**. Since the whole workflow rests on "wait for the Quality gate, then merge",
that is a hole worth closing in writing.

Fix documented in `CLAUDE.md` and `docs/issue-workflow.md`: poll until
`gh pr checks --json name --jq 'length'` is non-zero before watching, and use
`gh pr diff --name-only` against `paths-ignore` to tell the two cases apart.

Refs koniz-dev/flutter-starter#9