### PR TITLE
fix(tooling): make coverage.yml a valid, working workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,16 @@ jobs:
   coverage-analysis:
     name: Coverage Analysis
     runs-on: ubuntu-latest
+
+    # `pull-requests: write` is needed by the "Comment coverage summary" step.
+    # It MUST live here (job level) or at workflow level - GitHub rejects
+    # `permissions:` on an individual step, and an unparseable workflow file
+    # fails at startup on every push while ignoring its own `on:` triggers.
+    # Job-level permissions replace the workflow-level block wholesale, so
+    # `contents: read` is restated rather than inherited.
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
       - name: Checkout code
@@ -207,8 +217,6 @@ jobs:
       - name: Comment coverage summary
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2
-        permissions:
-          pull-requests: write
         with:
           recreate: true
           message: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
+          # No `flutter-version:` here. "stable" is a CHANNEL, not a version, and
+          # passing it as a version makes flutter-action fail with "Unable to
+          # determine Flutter version for channel: stable version: stable".
+          # ci.yml sets only `channel:`, which is why ci.yml has always worked.
           channel: 'stable'
           cache: true
       


### PR DESCRIPTION
`coverage.yml` has failed on **every recorded run since the repository's first
commit** (2025-11-18). Nine months of red that nobody read.

## Two defects

**1. Step-level `permissions:`** — only valid at workflow or job level:

```yaml
        uses: marocchino/sticky-pull-request-comment@v2
        permissions:            # <-- invalid here
          pull-requests: write
```

An unparseable workflow file fails at startup *and* has its `on:` triggers
ignored, which is why a `workflow_dispatch`-plus-`schedule` workflow was
producing failed runs on every **push**. Moved to job level (not deleted — the
step genuinely needs it). Job-level permissions replace the workflow-level block
wholesale, so `contents: read` is restated.

**2. `flutter-version: 'stable'`** — with the file parsing again, the run reached
Setup Flutter and failed:

```
Unable to determine Flutter version for channel: stable version: stable
```

`stable` is a **channel**, not a version. `ci.yml` passes only `channel:`, which
is why `ci.yml` has always worked.

## Result

`Coverage Analysis` now completes: run
[32866889161](https://github.com/koniz-dev/flutter-starter/actions/runs/32866889161),
`conclusion: success`, 3m5s. First successful run this repo has ever had.

```
lines......: 89.8% (3388 of 3772 lines)
Overall: 89.8%
Domain files: 15   Data files: 12   Presentation files: 11   Core files: 70
```

## What this does NOT fix

Be precise, since the docs overclaim. `docs/guides/testing/testing-summary.md`
and `test/README.md` advertise per-layer thresholds (domain 100%, data 90%+,
core/presentation 80%+). The "Calculate coverage metrics" step only **counts
files** per layer — `grep -c "^SF:.*domain"` — it never computes a per-layer
percentage, so those thresholds are still not enforced by anything. Only the
89.8% overall figure is real. Filing that separately rather than quietly
pretending this closes it.

The same `flutter-version: 'stable'` defect also exists in `build.yml`,
`deploy-android.yml`, `deploy-ios.yml`, `deploy-web.yml`, and `e2e-android.yml`
(11 occurrences across 6 files). Only `ci.yml` and `strip-smoke.yml` are clean —
which is exactly why this went unnoticed: those two are the only ones that run
on push. Tracked separately.

Refs koniz-dev/flutter-starter#21