### PR TITLE
fix(tooling): drop invalid flutter-version: stable from 5 workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 
@@ -86,7 +85,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 
@@ -125,7 +123,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 
@@ -113,7 +112,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 
@@ -165,7 +163,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 'stable'
           channel: 'stable'
           cache: true
 


### PR DESCRIPTION
`subosito/flutter-action@v2` takes `channel:` for a channel and
`flutter-version:` for a version. Passing `flutter-version: 'stable'` supplies a
channel name where a version is expected, and the action fails at once:

```
Unable to determine Flutter version for channel: stable version: stable
```

9 occurrences removed across `build.yml`, `deploy-{android,ios,web}.yml`, and
`e2e-android.yml`. Every `channel: 'stable'` is untouched, so the resolved SDK is
unchanged.

## Why nobody noticed for nine months

`ci.yml` and `strip-smoke.yml` were already clean - and they are exactly the two
workflows that run on every push. Every affected workflow is dispatch-only or
tag-gated, so nobody ever watched one start. **No deploy workflow has ever got
past its second step**, which means "missing credentials" was never actually the
reason they failed.

## Verified by dispatching, not asserted

| Workflow | Result |
|---|---|
| `build.yml` (web/development) | [run 32869019450](https://github.com/koniz-dev/flutter-starter/actions/runs/32869019450) - **success**, Build Web green in 1m25s, `web-build-development` artifact produced |
| `e2e-android.yml` | [run 32869023061](https://github.com/koniz-dev/flutter-starter/actions/runs/32869023061) - Set up job, Checkout, **Setup Flutter**, Setup Java, Install dependencies, Install Patrol CLI all green; reached "Run Patrol tests" on the emulator |

Deploy workflows are deliberately **not** dispatched here - they push to stores.
Out of scope, per criterion 5.

## This also makes the docs honest

`CLAUDE.md` and `docs/issue-workflow.md` both route tier-3 acceptance criteria to
"Actions -> E2E Android (Patrol) -> Run workflow". Until now that workflow could
not start at all, so `status:needs-uat` was undeliverable in practice - the human
receiving the hand-off would hit an immediate red run.

Refs koniz-dev/flutter-starter#24