### PR TITLE
test(tooling): acceptance evidence for #24

### DIFF
--- a/docs/verification/issue-24/analyze.log
+++ b/docs/verification/issue-24/analyze.log
@@ -1,0 +1,5 @@
+$ flutter analyze
+
+Analyzing flutter-starter...                                    
+No issues found! (ran in 3.9s)
+exit: 0

--- a/docs/verification/issue-24/audit_template.log
+++ b/docs/verification/issue-24/audit_template.log
@@ -1,0 +1,9 @@
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:15 +2229 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should create HomeScreen widget
+01:15 +2230 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should display welcome message
+01:15 +2231 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should have app bar with title
+01:15 +2232 ~1: All tests passed!
+exit: 0

--- a/docs/verification/issue-24/criteria-1-2-grep.txt
+++ b/docs/verification/issue-24/criteria-1-2-grep.txt
@@ -1,0 +1,17 @@
+# Criteria 1 and 2: invalid key gone, channel pins preserved
+
+$ grep -rn "flutter-version: 'stable'" .github/workflows/
+(no matches)
+
+$ grep -c "channel: 'stable'" .github/workflows/*.yml
+.github/workflows/coverage.yml:1
+.github/workflows/deploy-ios.yml:1
+.github/workflows/ci.yml:1
+.github/workflows/deploy-android.yml:1
+.github/workflows/build.yml:3
+.github/workflows/deploy-web.yml:3
+.github/workflows/strip-smoke.yml:1
+.github/workflows/e2e-android.yml:1
+
+Counts match the pre-fix values: build 3, deploy-web 3, and 1 each for
+ci, coverage, deploy-android, deploy-ios, e2e-android, strip-smoke.

--- a/docs/verification/issue-24/criteria-3-4-dispatch.txt
+++ b/docs/verification/issue-24/criteria-3-4-dispatch.txt
@@ -1,0 +1,27 @@
+# Criterion 3: build.yml dispatched (web/development)
+
+  run 32869019450  workflow_dispatch  fix/flutter-version-channel-confusion  completed/success
+JOBS
+✓ Build Web in 1m25s (ID 97871286986)
+- Build iOS (no codesign) in 0s (ID 97871288006)
+- Build Android (ID 97871340797)
+
+ANNOTATIONS
+  Setup Flutter passed and the whole Build Web job completed, producing
+  artifact web-build-development. Previously: failed at Setup Flutter.
+
+# Criterion 4: e2e-android.yml dispatched
+  run 32869023061  completed/failure
+JOBS
+X Patrol on Android emulator in 6m25s (ID 97871298897)
+  ✓ Set up job
+  ✓ Checkout code
+  ✓ Setup Flutter
+  ✓ Setup Java
+  ✓ Install dependencies
+  ✓ Add Pub global bin to PATH
+  ✓ Install Patrol CLI
+  X Run Patrol tests
+  ✓ Post Setup Java
+  ✓ Post Setup Flutter
+  ✓ Post Checkout code

--- a/docs/verification/issue-24/criterion-4-remaining-blocker.txt
+++ b/docs/verification/issue-24/criterion-4-remaining-blocker.txt
@@ -1,0 +1,17 @@
+# Criterion 4, continued: WHY e2e still fails, and why that is a different bug
+
+Setup Flutter, Setup Java, Install dependencies and Install Patrol CLI all
+pass. The failure is now inside 'Run Patrol tests':
+
+  Error: Patrol version 3.20.0 defined in your project is not compatible
+  with patrol_cli version 4.7.0.
+  This will prevent your tests from running correctly.
+  1. Downgrade patrol_cli ... dart pub global activate patrol_cli 3.11.0
+  2. Or upgrade both "patrol_cli" and "patrol" dependencies.
+
+NOTE: this is NOT the reason criterion 4 predicted. The issue expected a
+failure from the auth flow having no reachable API. The real blocker is a
+version incompatibility that occurs before any test executes, because
+e2e-android.yml runs 'dart pub global activate patrol_cli' unpinned while
+pubspec.yaml pins 'patrol: ^3.10.0'. Filed separately - not silently
+folded in here.

--- a/docs/verification/issue-24/criterion-5-deploy-out-of-scope.txt
+++ b/docs/verification/issue-24/criterion-5-deploy-out-of-scope.txt
@@ -1,0 +1,16 @@
+# Criterion 5: deploy workflows deliberately NOT dispatched
+
+deploy-android.yml, deploy-ios.yml and deploy-web.yml publish to app stores
+and a hosting target. Dispatching them to prove a Setup Flutter fix would
+risk a real release, so they were not run. The change to them is textually
+identical to the change verified in build.yml and e2e-android.yml: the same
+single line removed, no other edit.
+
+Commit: 7666a8421fbc59333bd4be85e332f9677ec5222c
+
+Diff applied to the three deploy workflows:
+-          flutter-version: 'stable'
+-          flutter-version: 'stable'
+-          flutter-version: 'stable'
+-          flutter-version: 'stable'
+-          flutter-version: 'stable'

--- a/docs/verification/issue-24/format.log
+++ b/docs/verification/issue-24/format.log
@@ -1,0 +1,4 @@
+$ dart format --set-exit-if-changed lib test integration_test tool examples
+
+Formatted 333 files (0 changed) in 1.03 seconds.
+exit: 0

--- a/docs/verification/issue-24/tests.log
+++ b/docs/verification/issue-24/tests.log
@@ -1,0 +1,124 @@
+$ flutter test --timeout=5m --reporter compact
+
+00:03 +53: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Debug utilities should have printConfig method                                             
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+00:03 +78: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Edge Cases printConfig should not throw in debug mode                                      
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+
+[... 686 lines elided by scripts/test/run_acceptance.sh.
+     Full output is reproducible by re-running the command above. ...]
+
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2221 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use light theme by default                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2222 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should have dark theme configured                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2223 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure router correctly                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2224 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure localization delegates                                                                     
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2225 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure supported locales                                                                          
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2226 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use locale from provider                                                                             
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2227 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure text direction from provider                                                               
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:17 +2228 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should wrap content in RepaintBoundary                                                                      
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:18 +2232 ~1: 1 skipped test.                                                                                                                                                                        
+01:18 +2232 ~1: All other tests passed!                                                                                                                                                                
+exit: 0


### PR DESCRIPTION
Evidence for the six criteria on #24, including the honest note that criterion 4's
predicted failure reason was wrong: e2e-android now fails on a patrol/patrol_cli
version incompatibility, not on the missing API. Filed separately.

Refs koniz-dev/flutter-starter#24