### PR TITLE
test(testing): acceptance evidence for #28

### DIFF
--- a/docs/verification/issue-28/analyze.log
+++ b/docs/verification/issue-28/analyze.log
@@ -1,0 +1,6 @@
+$ flutter analyze
+
+Upgrading analysis_options.yaml to exclude build and platform directories.
+Analyzing flutter-starter...                                    
+No issues found! (ran in 3.7s)
+exit: 0

--- a/docs/verification/issue-28/audit_template.log
+++ b/docs/verification/issue-28/audit_template.log
@@ -1,0 +1,9 @@
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:13 +2229 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should create HomeScreen widget
+01:13 +2230 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should display welcome message
+01:13 +2231 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should have app bar with title
+01:13 +2232 ~1: All tests passed!
+exit: 0

--- a/docs/verification/issue-28/criteria-1-4-pinned.txt
+++ b/docs/verification/issue-28/criteria-1-4-pinned.txt
@@ -1,0 +1,11 @@
+# Criteria 1 and 4: every patrol_cli activation is pinned
+
+$ grep -rn 'activate patrol_cli' --include='*.yml' --include='*.sh' --include='*.md' .
+README.md:100:Patrol does not run on every PR by default. Locally: `dart pub global activate patrol_cli 3.11.0` then `./scripts/test/run_e2e_tests.sh` (or `patrol test --target integration_test/app_e2e_test.dart`). On GitHub: **Actions → E2E Android (Patrol) → Run workflow** (Android emulator). Stable selectors use [`lib/core/constants/ui_keys.dart`](lib/core/constants/ui_keys.dart).
+integration_test/README.md:10:dart pub global activate patrol_cli 3.11.0
+docs/guides/testing/testing-summary.md:38:dart pub global activate patrol_cli 3.11.0
+scripts/test/run_e2e_tests.sh:4:# Requires patrol_cli globally: `dart pub global activate patrol_cli 3.11.0`
+scripts/test/run_e2e_tests.sh:22:    echo "Please install it by running: dart pub global activate patrol_cli 3.11.0"
+.github/workflows/e2e-android.yml:59:        run: dart pub global activate patrol_cli 3.11.0
+
+All five sites pin 3.11.0 and point at the Patrol compatibility table.

--- a/docs/verification/issue-28/criterion-2-compatibility-passed.txt
+++ b/docs/verification/issue-28/criterion-2-compatibility-passed.txt
@@ -1,0 +1,15 @@
+# Criterion 2: the run gets past the compatibility check
+
+Before the pin - run 32869023061, unpinned CLI:
+  + patrol_cli 4.7.0
+  Error: Patrol version 3.20.0 defined in your project is not compatible
+  with patrol_cli version 4.7.0.
+  -> aborted in seconds, no build, no emulator
+
+After the pin - run 32870753971:
+  + patrol_cli 3.11.0 (4.7.0 available)
+  Activated patrol_cli 3.11.0.
+  patrol test --target integration_test/app_e2e_test.dart
+  ✓ Completed building apk with entrypoint test_bundle.dart (139.5s)
+  • Executing tests of apk with entrypoint test_bundle.dart on emulator-5554...
+  -> compatibility check passed; APK built; emulator executed the bundle

--- a/docs/verification/issue-28/criterion-3-false-green.txt
+++ b/docs/verification/issue-28/criterion-3-false-green.txt
@@ -1,0 +1,23 @@
+# Criterion 3: what actually happened - NOT what this issue predicted
+
+Criterion 3 expected a failure from the auth flow having no reachable API.
+That premise was wrong. The run reports SUCCESS while executing NO tests:
+
+  Test summary:
+  📝 Total: 0
+  ✅ Successful: 0
+  ❌ Failed: 0
+  ⏩ Skipped: 0
+  ⏱️  Duration: 13s
+  ✓ Completed executing apk with entrypoint test_bundle.dart on emulator-5554
+
+  run 32870753971 -> conclusion: success
+
+patrol test exits 0 on an empty test set, so the job is a green tick that
+proves nothing. The auth flow was never reached, so the network was never
+the blocker. This is NOT a pass and is not described as one.
+
+Root cause - Patrol's native Android harness does not exist:
+  $ find android -path '*androidTest*'        -> (nothing)
+  $ grep -n testInstrumentationRunner android/app/build.gradle.kts -> (nothing)
+Filed as a separate issue rather than folded in here.

--- a/docs/verification/issue-28/criterion-5-docs.txt
+++ b/docs/verification/issue-28/criterion-5-docs.txt
@@ -1,0 +1,43 @@
+# Criterion 5: CLAUDE.md and docs/issue-workflow.md tell the truth now
+
+-- CLAUDE.md --
+- **Patrol E2E.** `integration_test/` and `patrol: ^3.10.0` exist, but
+  `patrol_cli` is not installed locally, no Android/iOS device or emulator is
+  connected (only macOS desktop and Chrome), and
+  [`e2e-android.yml`](.github/workflows/e2e-android.yml) is
+  `workflow_dispatch`-only by design. **A session cannot run Patrol.**
+  A human cannot usefully run it either, and the reason matters: **the workflow
+  goes green while running zero tests.** Run 32870753971 built the APK, booted
+  the emulator, and reported `Total: 0  Successful: 0  Failed: 0  Skipped: 0` -
+  then exited 0, so the job is a green tick that proves nothing. Patrol's native
+  Android harness was never scaffolded (no `android/app/src/androidTest/`, no
+  `testInstrumentationRunner`, no Patrol Gradle deps), so instrumentation finds
+  no tests to collect.
+  **Never cite a green E2E Android run as evidence.** Open the run and confirm
+  `Total:` is non-zero first. Keep `patrol_cli` pinned to the version matching
+  the `patrol` dependency; unpinned resolves an incompatible CLI and aborts
+  before any test runs.
+
+-- docs/issue-workflow.md --
+- **Patrol E2E.** `integration_test/` exists and `patrol: ^3.10.0` is in
+  `pubspec.yaml`, but `patrol_cli` is not installed locally, no Android or iOS
+  device or emulator is connected (only macOS desktop and Chrome), and
+  [`e2e-android.yml`](../.github/workflows/e2e-android.yml) is
+  `workflow_dispatch`-only by design. A session cannot run Patrol.
+
+  A human cannot usefully run it either, and the failure mode is the dangerous
+  kind: **the workflow reports success while executing zero tests.** Run
+  32870753971 built the APK, booted the emulator, and printed
+  `Total: 0  Successful: 0  Failed: 0  Skipped: 0` before exiting 0.
+
+  The cause is that Patrol's native Android harness was never scaffolded: there
+  is no `android/app/src/androidTest/` source set, no
+  `testInstrumentationRunner` in `android/app/build.gradle.kts`, and no Patrol
+  Gradle dependencies. Instrumentation therefore collects nothing. A pinned
+  `patrol_cli` gets past the compatibility check, which is necessary but not
+  sufficient.
+
+  Consequences for a `needs-uat` hand-off: do not send a human to that workflow
+  and treat a green tick as verification. If you must reference it, tell them to
+  open the run and check that `Total:` is non-zero - a green job with `Total: 0`
+  is a false pass, not evidence.

--- a/docs/verification/issue-28/format.log
+++ b/docs/verification/issue-28/format.log
@@ -1,0 +1,4 @@
+$ dart format --set-exit-if-changed lib test integration_test tool examples
+
+Formatted 333 files (0 changed) in 1.03 seconds.
+exit: 0

--- a/docs/verification/issue-28/tests.log
+++ b/docs/verification/issue-28/tests.log
@@ -1,0 +1,124 @@
+$ flutter test --timeout=5m --reporter compact
+
+00:02 +50: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Debug utilities should have printConfig method                                             
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+00:02 +78: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Edge Cases printConfig should not throw in debug mode                                      
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+
+[... 684 lines elided by scripts/test/run_acceptance.sh.
+     Full output is reproducible by re-running the command above. ...]
+
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:15 +2221 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use light theme by default                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:15 +2222 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should have dark theme configured                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:15 +2223 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure router correctly                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2224 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure localization delegates                                                                     
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2225 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure supported locales                                                                          
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2226 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use locale from provider                                                                             
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2227 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure text direction from provider                                                               
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2228 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should wrap content in RepaintBoundary                                                                      
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2232 ~1: 1 skipped test.                                                                                                                                                                        
+01:16 +2232 ~1: All other tests passed!                                                                                                                                                                
+exit: 0


### PR DESCRIPTION
Evidence for #28, including the honest record that criterion 3's premise was wrong:
the run does not fail on the network, it reports success having executed zero tests.

Refs koniz-dev/flutter-starter#28