### PR TITLE
fix(testing): scaffold the Patrol native Android harness

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -64,7 +64,11 @@ jobs:
           api-level: ${{ inputs.api_level }}
           arch: x86_64
           profile: ${{ inputs.emulator_profile }}
-          script: patrol test --target integration_test/app_e2e_test.dart 2>&1 | tee patrol-output.log
+          # `bash -o pipefail` is load-bearing. The emulator-runner executes this
+          # via /usr/bin/sh, so a bare `patrol test ... | tee` returns tee's exit
+          # status and a FAILING test set reports as a green job. Verified: a run
+          # with "Failed: 1" concluded success until this was added.
+          script: bash -o pipefail -c 'patrol test --target integration_test/app_e2e_test.dart 2>&1 | tee patrol-output.log'
 
       # `patrol test` exits 0 on an EMPTY test set. Before the native androidTest
       # source set existed, this job went green reporting "Total: 0" - a tick that
@@ -86,7 +90,12 @@ jobs:
             echo "::error::Patrol collected 0 tests. A green run here would be a false pass."
             exit 1
           fi
-          echo "OK: $total test(s) were actually collected and executed."
+          failed="$(grep -oE 'Failed: *[0-9]+' patrol-output.log | tail -1 | grep -oE '[0-9]+' || echo 0)"
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::$failed of $total Patrol test(s) failed. See the patrol-output artifact."
+            exit 1
+          fi
+          echo "OK: $total test(s) collected and executed, 0 failed."
 
       - name: Upload Patrol output
         if: always()

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -64,4 +64,34 @@ jobs:
           api-level: ${{ inputs.api_level }}
           arch: x86_64
           profile: ${{ inputs.emulator_profile }}
-          script: patrol test --target integration_test/app_e2e_test.dart
+          script: patrol test --target integration_test/app_e2e_test.dart 2>&1 | tee patrol-output.log
+
+      # `patrol test` exits 0 on an EMPTY test set. Before the native androidTest
+      # source set existed, this job went green reporting "Total: 0" - a tick that
+      # verified nothing, which is worse than a red. Never let that recur.
+      - name: Reject an empty test run
+        if: always()
+        run: |
+          if [ ! -f patrol-output.log ]; then
+            echo "::error::patrol-output.log missing - the test step never produced output."
+            exit 1
+          fi
+          total="$(grep -oE 'Total: *[0-9]+' patrol-output.log | tail -1 | grep -oE '[0-9]+' || true)"
+          echo "Patrol reported test count: ${total:-<none>}"
+          if [ -z "$total" ]; then
+            echo "::error::No 'Total:' summary in patrol output; cannot confirm any test ran."
+            exit 1
+          fi
+          if [ "$total" -eq 0 ]; then
+            echo "::error::Patrol collected 0 tests. A green run here would be a false pass."
+            exit 1
+          fi
+          echo "OK: $total test(s) were actually collected and executed."
+
+      - name: Upload Patrol output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: patrol-output
+          path: patrol-output.log
+          if-no-files-found: warn

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,6 +28,18 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        // Patrol E2E (integration_test/). Required for the androidTest source
+        // set to be discovered; without it `patrol test` collects 0 tests and
+        // still exits 0. Harmless for normal app builds.
+        testInstrumentationRunner = "pl.leancode.patrol.PatrolJUnitRunner"
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    }
+
+    // Patrol runs each Dart test in a fresh process via the AndroidX test
+    // orchestrator, so state does not leak between tests.
+    testOptions {
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
     buildTypes {
@@ -41,4 +53,9 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Test-only: pulled in for androidTest variants, not shipped in the app.
+    androidTestUtil("androidx.test:orchestrator:1.5.1")
 }

--- a/android/app/src/androidTest/java/com/example/flutter_starter/MainActivityTest.java
+++ b/android/app/src/androidTest/java/com/example/flutter_starter/MainActivityTest.java
@@ -1,0 +1,40 @@
+package com.example.flutter_starter;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import pl.leancode.patrol.PatrolJUnitRunner;
+
+// Native entry point that lets Patrol enumerate and run the Dart tests in
+// integration_test/. Without this source set the instrumentation collects
+// nothing, `patrol test` reports "Total: 0" and still exits 0 - a green run that
+// verified nothing. See docs/guides/testing/testing-summary.md.
+//
+// If you rename the application id, this package and MainActivity must move with
+// it, or `listDartTests()` will not find the app.
+@RunWith(Parameterized.class)
+public class MainActivityTest {
+    @Parameters(name = "{0}")
+    public static Object[] testCases() {
+        PatrolJUnitRunner instrumentation =
+                (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.setUp(MainActivity.class);
+        instrumentation.waitForPatrolAppService();
+        return instrumentation.listDartTests();
+    }
+
+    public MainActivityTest(String dartTestName) {
+        this.dartTestName = dartTestName;
+    }
+
+    private final String dartTestName;
+
+    @Test
+    public void runDartTest() {
+        PatrolJUnitRunner instrumentation =
+                (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.runDartTest(dartTestName);
+    }
+}


### PR DESCRIPTION
Patrol needs a native instrumentation entry point to enumerate the Dart tests in
`integration_test/`. None existed, so the emulator ran an APK with no collectable
tests, `patrol test` printed `Total: 0`, exited 0, and the job went green having
verified nothing.

## Added

Following the canonical layout shipped in patrol 3.20.0's own `example/`:

- `android/app/src/androidTest/java/com/example/flutter_starter/MainActivityTest.java`,
  parameterised over `instrumentation.listDartTests()`.
- `testInstrumentationRunner = "pl.leancode.patrol.PatrolJUnitRunner"` and
  `clearPackageData` in `defaultConfig`.
- `testOptions { execution = "ANDROIDX_TEST_ORCHESTRATOR" }`.
- `androidTestUtil("androidx.test:orchestrator:1.5.1")`, test-only.

## It works

[Run 32966672465](https://github.com/koniz-dev/flutter-starter/actions/runs/32966672465):

```
📝 Total: 1        ← was 0
✅ Successful: 0
❌ Failed: 1
```

The test is now genuinely collected and executed. It **fails**, for the reason
originally predicted: `expect($(#e2e_home_content), findsOneWidget)` at
`app_e2e_test.dart:20` finds nothing, because the login flow calls a backend that
does not exist in CI. That is an honest red, and I am not calling it a pass.

## A bug I introduced, and fixed

My first version piped through `tee`. The emulator-runner runs its `script:` via
POSIX `sh`, where a bare pipe returns **tee's** exit status - so patrol raising
`Exception: Gradle test execution failed with code 1` was swallowed and the run
above concluded **success** while reporting `Failed: 1`. Same `pipefail` mistake I
had already fixed once in `run_acceptance.sh`.

Verified rather than assumed:

```
/bin/sh -c 'false | tee'          -> exit 0   (the bug)
bash -o pipefail -c 'false | tee' -> exit 1   (the fix)
bash -o pipefail -c 'true  | tee' -> exit 0   (still propagates success)
```

Defence in depth: the guard step now also fails on a non-zero `Failed:` count, so
the job goes red even if an exit code lies again. Guard logic exercised against
synthetic summaries for all five branches - `Total 0` fail, `Total 1/Failed 1`
fail, `Total 2/Failed 0` pass, no summary fail, log absent fail.

## Note on the Android app build

I dispatched `build.yml` (android) as a safety check on the Gradle edit. It
failed - but **not** on my change: Gradle configured fine and then reported
`Task 'assembleDevelopmentRelease' not found ... does not define any custom
product flavors`. `build.yml` passes `--flavor development` to a project with no
flavors. Pre-existing, filed separately. The Gradle edit is proven good by the
E2E run above, which builds both the app and androidTest APKs.

## Why scaffold rather than delete Patrol

The README advertises E2E as a key feature and every fork inherits what ships
here. A starter should not hand people a green button that means nothing.

Refs koniz-dev/flutter-starter#30