### PR TITLE
test(testing): acceptance evidence for #30; docs match the working harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,17 +102,16 @@ make the loop worthless.
   connected (only macOS desktop and Chrome), and
   [`e2e-android.yml`](.github/workflows/e2e-android.yml) is
   `workflow_dispatch`-only by design. **A session cannot run Patrol.**
-  A human cannot usefully run it either, and the reason matters: **the workflow
-  goes green while running zero tests.** Run 32870753971 built the APK, booted
-  the emulator, and reported `Total: 0  Successful: 0  Failed: 0  Skipped: 0` -
-  then exited 0, so the job is a green tick that proves nothing. Patrol's native
-  Android harness was never scaffolded (no `android/app/src/androidTest/`, no
-  `testInstrumentationRunner`, no Patrol Gradle deps), so instrumentation finds
-  no tests to collect.
-  **Never cite a green E2E Android run as evidence.** Open the run and confirm
-  `Total:` is non-zero first. Keep `patrol_cli` pinned to the version matching
-  the `patrol` dependency; unpinned resolves an incompatible CLI and aborts
-  before any test runs.
+  A **human** can now run it: Actions -> E2E Android (Patrol) -> Run workflow.
+  The native harness exists (`android/app/src/androidTest/`,
+  `PatrolJUnitRunner`, orchestrator) and run 32966672465 collected and executed a
+  real test (`Total: 1`). The job also fails on `Total: 0` or a non-zero
+  `Failed:` count, so a green run there is now trustworthy - that was not true
+  before, when it went green having run nothing.
+  Two live caveats: the shipped test still **fails without a reachable backend**
+  (the auth flow posts to `BASE_URL`), so a `needs-uat` hand-off must say whether
+  the human has an API; and `patrol_cli` must stay pinned to the version matching
+  the `patrol` dependency, or it aborts before any test runs.
 - **Real device behavior**, including everything RASP (`lib/core/security/` is a
   no-op by default and only meaningful on a real device).
 - **Gestures**: hover, right-click, drag, long-press discoverability,

--- a/docs/issue-workflow.md
+++ b/docs/issue-workflow.md
@@ -580,22 +580,23 @@ Route these to `status:needs-uat`:
   [`e2e-android.yml`](../.github/workflows/e2e-android.yml) is
   `workflow_dispatch`-only by design. A session cannot run Patrol.
 
-  A human cannot usefully run it either, and the failure mode is the dangerous
-  kind: **the workflow reports success while executing zero tests.** Run
-  32870753971 built the APK, booted the emulator, and printed
-  `Total: 0  Successful: 0  Failed: 0  Skipped: 0` before exiting 0.
+  A human can, through Actions -> E2E Android (Patrol) -> Run workflow, and that
+  path is now real: the native harness exists
+  (`android/app/src/androidTest/java/.../MainActivityTest.java`,
+  `PatrolJUnitRunner`, the AndroidX orchestrator) and run 32966672465 collected
+  and executed a genuine test (`Total: 1`).
 
-  The cause is that Patrol's native Android harness was never scaffolded: there
-  is no `android/app/src/androidTest/` source set, no
-  `testInstrumentationRunner` in `android/app/build.gradle.kts`, and no Patrol
-  Gradle dependencies. Instrumentation therefore collects nothing. A pinned
-  `patrol_cli` gets past the compatibility check, which is necessary but not
-  sufficient.
+  Two things to put in the hand-off comment.
 
-  Consequences for a `needs-uat` hand-off: do not send a human to that workflow
-  and treat a green tick as verification. If you must reference it, tell them to
-  open the run and check that `Total:` is non-zero - a green job with `Total: 0`
-  is a false pass, not evidence.
+  First, **the shipped test fails without a reachable backend.** The sample auth
+  flow posts to `BASE_URL`; with no server the app stays on the login screen and
+  `expect($(#e2e_home_content), findsOneWidget)` finds nothing. Ask whether the
+  human has an API before sending them there.
+
+  Second, a green run is now trustworthy, which it was not before. The job fails
+  when the summary reports `Total: 0` or a non-zero `Failed:` count, closing two
+  false-green paths: an empty test set (`patrol test` exits 0 on one) and a
+  failing set whose exit code was swallowed by a pipe without `pipefail`.
 - **Real device behavior.** Anything RASP-related
   (`lib/core/security/`) is a no-op by default and only becomes meaningful on a
   real device with a real implementation wired in.

--- a/docs/verification/issue-30/analyze.log
+++ b/docs/verification/issue-30/analyze.log
@@ -1,0 +1,6 @@
+$ flutter analyze
+
+Upgrading analysis_options.yaml to exclude build and platform directories.
+Analyzing flutter-starter...                                    
+No issues found! (ran in 3.8s)
+exit: 0

--- a/docs/verification/issue-30/audit_template.log
+++ b/docs/verification/issue-30/audit_template.log
@@ -1,0 +1,9 @@
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:13 +2229 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should create HomeScreen widget
+01:13 +2230 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should display welcome message
+01:14 +2231 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: HomeScreen should have app bar with title
+01:14 +2232 ~1: All tests passed!
+exit: 0

--- a/docs/verification/issue-30/criteria-1-2-7-harness.txt
+++ b/docs/verification/issue-30/criteria-1-2-7-harness.txt
@@ -1,0 +1,13 @@
+# Criteria 1, 2, 7: the native harness exists and analysis is unaffected
+
+$ find android -path '*androidTest*' -name '*.java'
+android/app/src/androidTest/java/com/example/flutter_starter/MainActivityTest.java
+
+$ grep -n testInstrumentationRunner android/app/build.gradle.kts
+35:        testInstrumentationRunner = "pl.leancode.patrol.PatrolJUnitRunner"
+36:        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+42:        execution = "ANDROIDX_TEST_ORCHESTRATOR"
+60:    androidTestUtil("androidx.test:orchestrator:1.5.1")
+
+$ flutter analyze  (android/** is excluded from analysis)
+No issues found! (ran in 2.5s)

--- a/docs/verification/issue-30/criteria-3-4-total-nonzero.txt
+++ b/docs/verification/issue-30/criteria-3-4-total-nonzero.txt
@@ -1,0 +1,19 @@
+# Criteria 3 and 4: a real test is collected, and it fails honestly
+
+BEFORE (run 32870753971, no harness):
+  📝 Total: 0   ✅ Successful: 0   ❌ Failed: 0   ⏩ Skipped: 0
+  conclusion: success  <- a green tick that verified nothing
+
+AFTER (run 32966672465, harness scaffolded):
+  📝 Total: 1   ✅ Successful: 0   ❌ Failed: 1   ⏩ Skipped: 0
+  ❌ E2E: auth -> home (stable ValueKeys) (integration_test/app_e2e_test.dart) (12s)
+  Expected: exactly one matching candidate
+  [<'e2e_home_content'>]: []
+  Which: means none were found but one was expected
+  app_e2e_test.dart line 20
+  Exception: Gradle test execution failed with code 1
+
+Criterion 3: Total went 0 -> 1. The harness collects and runs the test.
+Criterion 4: the test FAILS because the auth flow posts to BASE_URL and no
+  server exists in CI. Reported as a failure, NOT as a pass. Making the
+  shipped suite green without a backend is filed as a separate issue.

--- a/docs/verification/issue-30/criterion-5-no-false-green.txt
+++ b/docs/verification/issue-30/criterion-5-no-false-green.txt
@@ -1,0 +1,16 @@
+# Criterion 5: an empty or failing run can no longer present as green
+
+Guard logic exercised against synthetic patrol summaries:
+  Total: 0                  -> exit 1  'collected 0 tests ... false pass'
+  Total: 1, Failed: 1       -> exit 1  '1 of 1 Patrol test(s) failed'
+  Total: 2, Failed: 0       -> exit 0  'OK: 2 test(s) ... 0 failed'
+  no Total: summary at all   -> exit 1  'cannot confirm any test ran'
+  patrol-output.log missing  -> exit 1  'the test step never produced output'
+
+Also fixed a false green I introduced myself: the emulator-runner executes
+its script via POSIX sh, where 'patrol test | tee' returns tee's status.
+Run 32966672465 concluded SUCCESS while reporting Failed: 1 because of it.
+Verified on this machine:
+  /bin/sh -c 'false | tee'          -> exit 0   (the bug)
+  bash -o pipefail -c 'false | tee' -> exit 1   (the fix)
+  bash -o pipefail -c 'true  | tee' -> exit 0   (success still propagates)

--- a/docs/verification/issue-30/criterion-6-docs.txt
+++ b/docs/verification/issue-30/criterion-6-docs.txt
@@ -1,0 +1,43 @@
+# Criterion 6: CLAUDE.md and docs/issue-workflow.md now describe reality
+
+-- CLAUDE.md --
+- **Patrol E2E.** `integration_test/` and `patrol: ^3.10.0` exist, but
+  `patrol_cli` is not installed locally, no Android/iOS device or emulator is
+  connected (only macOS desktop and Chrome), and
+  [`e2e-android.yml`](.github/workflows/e2e-android.yml) is
+  `workflow_dispatch`-only by design. **A session cannot run Patrol.**
+  A **human** can now run it: Actions -> E2E Android (Patrol) -> Run workflow.
+  The native harness exists (`android/app/src/androidTest/`,
+  `PatrolJUnitRunner`, orchestrator) and run 32966672465 collected and executed a
+  real test (`Total: 1`). The job also fails on `Total: 0` or a non-zero
+  `Failed:` count, so a green run there is now trustworthy - that was not true
+  before, when it went green having run nothing.
+  Two live caveats: the shipped test still **fails without a reachable backend**
+  (the auth flow posts to `BASE_URL`), so a `needs-uat` hand-off must say whether
+  the human has an API; and `patrol_cli` must stay pinned to the version matching
+  the `patrol` dependency, or it aborts before any test runs.
+
+-- docs/issue-workflow.md --
+- **Patrol E2E.** `integration_test/` exists and `patrol: ^3.10.0` is in
+  `pubspec.yaml`, but `patrol_cli` is not installed locally, no Android or iOS
+  device or emulator is connected (only macOS desktop and Chrome), and
+  [`e2e-android.yml`](../.github/workflows/e2e-android.yml) is
+  `workflow_dispatch`-only by design. A session cannot run Patrol.
+
+  A human can, through Actions -> E2E Android (Patrol) -> Run workflow, and that
+  path is now real: the native harness exists
+  (`android/app/src/androidTest/java/.../MainActivityTest.java`,
+  `PatrolJUnitRunner`, the AndroidX orchestrator) and run 32966672465 collected
+  and executed a genuine test (`Total: 1`).
+
+  Two things to put in the hand-off comment.
+
+  First, **the shipped test fails without a reachable backend.** The sample auth
+  flow posts to `BASE_URL`; with no server the app stays on the login screen and
+  `expect($(#e2e_home_content), findsOneWidget)` finds nothing. Ask whether the
+  human has an API before sending them there.
+
+  Second, a green run is now trustworthy, which it was not before. The job fails
+  when the summary reports `Total: 0` or a non-zero `Failed:` count, closing two
+  false-green paths: an empty test set (`patrol test` exits 0 on one) and a
+  failing set whose exit code was swallowed by a pipe without `pipefail`.

--- a/docs/verification/issue-30/format.log
+++ b/docs/verification/issue-30/format.log
@@ -1,0 +1,4 @@
+$ dart format --set-exit-if-changed lib test integration_test tool examples
+
+Formatted 333 files (0 changed) in 1.02 seconds.
+exit: 0

--- a/docs/verification/issue-30/tests.log
+++ b/docs/verification/issue-30/tests.log
@@ -1,0 +1,124 @@
+$ flutter test --timeout=5m --reporter compact
+
+00:02 +50: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Debug utilities should have printConfig method                                             
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+00:02 +76: /Users/nguyenanhkiet/Playground/flutter-starter/test/core/config/app_config_test.dart: AppConfig Edge Cases printConfig should not throw in debug mode                                      
+═══════════════════════════════════════════════════════════
+📱 App Configuration
+═══════════════════════════════════════════════════════════
+Environment: development
+Debug Mode: true
+Release Mode: false
+
+🌐 API Configuration:
+  Base URL: http://localhost:3000
+  Timeout: 30s
+  Connect Timeout: 10s
+  Receive Timeout: 30s
+  Send Timeout: 30s
+  SSL Pinning Enabled: false
+  SSL Fingerprints Configured: 0
+
+🚩 Feature Flags:
+  Logging: true
+  Analytics: false
+  Crash Reporting: false
+  Performance Monitoring: false
+  Debug Features: true
+  HTTP Logging: true
+
+📦 App Info:
+  Version: 1.0.0
+  Build Number: 1
+═══════════════════════════════════════════════════════════
+
+[... 683 lines elided by scripts/test/run_acceptance.sh.
+     Full output is reproducible by re-running the command above. ...]
+
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:15 +2221 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use light theme by default                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2222 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should have dark theme configured                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2223 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure router correctly                                                                           
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2224 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure localization delegates                                                                     
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2225 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure supported locales                                                                          
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2226 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should use locale from provider                                                                             
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2227 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should configure text direction from provider                                                               
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2228 ~1: /Users/nguyenanhkiet/Playground/flutter-starter/test/main_test.dart: MyApp should wrap content in RepaintBoundary                                                                      
+┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+│ #0   LoggingService.info (package:flutter_starter/core/logging/logging_service.dart:123:13)
+│ #1   NavigationLoggingObserver._logNavigation (package:flutter_starter/core/routing/navigation_logging.dart:73:21)
+├┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+│ 💡 Navigation: Route Pushed | Context: {"routeName":"login","routePath":"login"}
+└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+01:16 +2232 ~1: 1 skipped test.                                                                                                                                                                        
+01:16 +2232 ~1: All other tests passed!                                                                                                                                                                
+exit: 0


### PR DESCRIPTION
Evidence for #30, plus criterion 6: CLAUDE.md and docs/issue-workflow.md now say the
Patrol hand-off is real, that a green run is trustworthy (Total: 0 and Failed: >0 both
fail the job), and that the shipped test still needs a backend.

Refs koniz-dev/flutter-starter#30