### PR TITLE
fix(tooling): stop passing --flavor to a project with no product flavors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,14 @@ on:
           - android
           - ios
           - web
-      flavor:
-        description: 'App flavor (must exist in your project)'
+      # NOT a Gradle product flavor. This project configures itself through
+      # `.env` layering and --dart-define (see docs/guides/configuration.md and
+      # lib/core/config/app_config.dart, which reads ENVIRONMENT). No
+      # productFlavors are declared in android/app/build.gradle.kts, so passing
+      # --flavor made `flutter build apk` fail with
+      # "Task 'assembleDevelopmentRelease' not found".
+      environment:
+        description: 'Value passed as --dart-define=ENVIRONMENT'
         required: true
         default: 'development'
         type: choice
@@ -28,7 +34,7 @@ on:
         default: ''
 
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.flavor }}
+  group: build-${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.environment }}
   cancel-in-progress: true
 
 permissions:
@@ -56,21 +62,20 @@ jobs:
       - name: Build APK
         shell: bash
         run: |
-          FLAVOR="${{ inputs.flavor }}"
+          ENVIRONMENT="${{ inputs.environment }}"
           BASE_URL="${{ inputs.base_url }}"
           if [ -z "$BASE_URL" ]; then
             BASE_URL="http://localhost:3000"
           fi
 
           flutter build apk \
-            --flavor "$FLAVOR" \
-            --dart-define=ENVIRONMENT="$FLAVOR" \
+            --dart-define=ENVIRONMENT="$ENVIRONMENT" \
             --dart-define=BASE_URL="$BASE_URL"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: android-apks-${{ inputs.flavor }}
+          name: android-apks-${{ inputs.environment }}
           path: build/app/outputs/flutter-apk/*.apk
 
   build-ios:
@@ -99,16 +104,15 @@ jobs:
       - name: Build iOS
         shell: bash
         run: |
-          FLAVOR="${{ inputs.flavor }}"
+          ENVIRONMENT="${{ inputs.environment }}"
           BASE_URL="${{ inputs.base_url }}"
           if [ -z "$BASE_URL" ]; then
             BASE_URL="http://localhost:3000"
           fi
 
           flutter build ios \
-            --flavor "$FLAVOR" \
             --no-codesign \
-            --dart-define=ENVIRONMENT="$FLAVOR" \
+            --dart-define=ENVIRONMENT="$ENVIRONMENT" \
             --dart-define=BASE_URL="$BASE_URL"
 
   build-web:
@@ -132,19 +136,19 @@ jobs:
       - name: Build Web
         shell: bash
         run: |
-          FLAVOR="${{ inputs.flavor }}"
+          ENVIRONMENT="${{ inputs.environment }}"
           BASE_URL="${{ inputs.base_url }}"
           if [ -z "$BASE_URL" ]; then
             BASE_URL="http://localhost:3000"
           fi
 
           flutter build web \
-            --dart-define=ENVIRONMENT="$FLAVOR" \
+            --dart-define=ENVIRONMENT="$ENVIRONMENT" \
             --dart-define=BASE_URL="$BASE_URL"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: web-build-${{ inputs.flavor }}
+          name: web-build-${{ inputs.environment }}
           path: build/web
 

--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -93,7 +93,6 @@ jobs:
       #     fi
           
       #     flutter build appbundle \
-      #       --flavor "$ENV" \
       #       --release \
       #       --dart-define=ENVIRONMENT="$ENV" \
       #       --dart-define=BASE_URL="$BASE_URL"


### PR DESCRIPTION
`build.yml` offered a `flavor` input and passed it to `flutter build` for Android
and iOS. `android/app/build.gradle.kts` declares no `productFlavors`, so:

```
Task 'assembleDevelopmentRelease' not found in root project 'android'
[!] The android/app/build.gradle.kts file does not define any custom product
    flavors. You cannot use the --flavor option.
```

## The working code path settled the design question

The **web** job in the same workflow already omitted `--flavor` and passed only
`--dart-define=ENVIRONMENT` - which is why web was the one platform that built.
That is the project's actual convention, not a workaround:

- `lib/core/config/app_config.dart:33` reads `ENVIRONMENT` from `.env` or
  `--dart-define`.
- `docs/guides/configuration.md` documents env layering and dart-defines.
- No `productFlavors` have ever existed in the Gradle config.

So I dropped `--flavor` rather than inventing flavors. Adding real ones would also
require iOS schemes, which cannot be created from a script here, and would add
surface a starter does not need.

## Renamed the input

`flavor` -> `environment`, described as "Value passed as
`--dart-define=ENVIRONMENT`". Calling it a flavor is what made the mistake
plausible in the first place. Artifact names and the concurrency group follow the
rename.

## Verified by dispatching

| Run | Result |
|---|---|
| [32971439671](https://github.com/koniz-dev/flutter-starter/actions/runs/32971439671) `platform=android` | **success** in 6m23s, artifact `android-apks-development` (32,223,960 bytes) |
| [32971452663](https://github.com/koniz-dev/flutter-starter/actions/runs/32971452663) `platform=web` | **success** in 1m17s, artifact `web-build-development` (14,226,706 bytes) - not regressed |

That Android APK is the first this repository has ever produced in CI.

## Deploy workflows

`deploy-android.yml` had `--flavor "$ENV"` inside its commented-out build
template; removed, so uncommenting it does not reproduce the bug.
`deploy-ios.yml` turned out to have no such line - I asserted it did and the
assertion caught me. Neither was dispatched: they publish to stores.

Refs koniz-dev/flutter-starter#34