### PR TITLE
fix(tooling): stop coverage.yml conflating file counts with coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -98,13 +98,15 @@ jobs:
         id: layer_coverage
         run: |
           chmod +x scripts/test/calculate_layer_coverage.sh
-          ./scripts/test/calculate_layer_coverage.sh coverage/lcov.info > /tmp/layer_coverage.txt
 
-          while IFS='=' read -r key value; do
-            echo "${key}=${value}" >> $GITHUB_OUTPUT
-          done < /tmp/layer_coverage.txt
+          # --github-output emits ONLY key=value lines. The previous version
+          # appended the script's human summary too, so prose like
+          # "Summary of coverage by layer" became a step-output key (#39).
+          ./scripts/test/calculate_layer_coverage.sh --github-output coverage/lcov.info \
+            >> "$GITHUB_OUTPUT"
 
-          cat /tmp/layer_coverage.txt
+          # And print the readable form for whoever is reading the log.
+          ./scripts/test/calculate_layer_coverage.sh coverage/lcov.info
 
       - name: Calculate coverage metrics
         id: metrics
@@ -112,24 +114,27 @@ jobs:
           # Overall coverage
           OVERALL=$(lcov --summary coverage/lcov.info 2>&1 | grep "lines.*:" | head -1 | grep -oP '\d+\.\d+%' | head -1 | sed 's/%//' || echo "0")
           
-          # Coverage by layer (simplified)
-          DOMAIN_TOTAL=$(grep "^SF:.*lib/features/.*/domain" coverage/lcov.info | wc -l || echo "0")
-          DATA_TOTAL=$(grep "^SF:.*lib/features/.*/data" coverage/lcov.info | wc -l || echo "0")
-          PRESENTATION_TOTAL=$(grep "^SF:.*lib/features/.*/presentation" coverage/lcov.info | wc -l || echo "0")
-          CORE_TOTAL=$(grep "^SF:.*lib/core" coverage/lcov.info | wc -l || echo "0")
-          
+          # File counts, kept only as context. They are NOT coverage - labelling
+          # them "Domain files: 15" beside a percentage is what made issue #25
+          # look like a real defect. Per-layer percentages come from the
+          # layer_coverage step above.
+          DOMAIN_FILES=$(grep -c "^SF:.*lib/features/.*/domain" coverage/lcov.info || echo "0")
+          DATA_FILES=$(grep -c "^SF:.*lib/features/.*/data" coverage/lcov.info || echo "0")
+          PRESENTATION_FILES=$(grep -c "^SF:.*lib/features/.*/presentation" coverage/lcov.info || echo "0")
+          CORE_FILES=$(grep -c "^SF:.*lib/core" coverage/lcov.info || echo "0")
+
           echo "overall=$OVERALL" >> $GITHUB_OUTPUT
-          echo "domain_files=$DOMAIN_TOTAL" >> $GITHUB_OUTPUT
-          echo "data_files=$DATA_TOTAL" >> $GITHUB_OUTPUT
-          echo "presentation_files=$PRESENTATION_TOTAL" >> $GITHUB_OUTPUT
-          echo "core_files=$CORE_TOTAL" >> $GITHUB_OUTPUT
-          
-          echo "📊 Coverage Metrics:"
-          echo "  Overall: ${OVERALL}%"
-          echo "  Domain files: ${DOMAIN_TOTAL}"
-          echo "  Data files: ${DATA_TOTAL}"
-          echo "  Presentation files: ${PRESENTATION_TOTAL}"
-          echo "  Core files: ${CORE_TOTAL}"
+          echo "domain_files=$DOMAIN_FILES" >> $GITHUB_OUTPUT
+          echo "data_files=$DATA_FILES" >> $GITHUB_OUTPUT
+          echo "presentation_files=$PRESENTATION_FILES" >> $GITHUB_OUTPUT
+          echo "core_files=$CORE_FILES" >> $GITHUB_OUTPUT
+
+          echo "📊 Overall line coverage: ${OVERALL}%"
+          echo ""
+          echo "Source files measured per layer (counts, not coverage):"
+          echo "  domain: ${DOMAIN_FILES}   data: ${DATA_FILES}   presentation: ${PRESENTATION_FILES}   core: ${CORE_FILES}"
+          echo "Per-layer coverage percentages are reported by the"
+          echo "'Calculate coverage by layer (architecture gates)' step above."
 
       - name: Enforce coverage thresholds
         run: |

--- a/docs/guides/testing/test-coverage.md
+++ b/docs/guides/testing/test-coverage.md
@@ -66,16 +66,26 @@ Main coverage script with options:
 
 #### calculate_layer_coverage.sh
 
-Analyzes coverage by layer:
+Reports the percentage of executable lines covered, per architectural layer:
 
 ```bash
-./scripts/test/calculate_layer_coverage.sh
+./scripts/test/calculate_layer_coverage.sh                       # human summary
+./scripts/test/calculate_layer_coverage.sh --github-output       # key=value only
 ```
 
-Output shows:
-- Coverage by layer (Domain, Data, Presentation, Core, Shared)
-- Files with low coverage (< 60%)
-- Coverage percentages per component
+```
+Coverage by layer (percentage of executable lines covered):
+  Domain:       100.0%
+  Data:         96.2%
+  Presentation: 93.5%
+  Core:         85.2%
+```
+
+Four layers only — `domain`, `data`, `presentation` and `core`. It does **not**
+list individual low-coverage files, and there is no `shared` layer figure; this
+description previously claimed both. `--github-output` exists so
+[`coverage.yml`](../../../.github/workflows/coverage.yml) can append the values
+straight to `$GITHUB_OUTPUT` without the human text becoming step-output keys.
 
 ## CI/CD Coverage
 

--- a/scripts/test/calculate_layer_coverage.sh
+++ b/scripts/test/calculate_layer_coverage.sh
@@ -4,7 +4,23 @@
 
 set -e
 
-LCOV_FILE="${1:-coverage/lcov.info}"
+# Two output modes, deliberately separated:
+#   (default)         human summary, for a developer running this by hand
+#   --github-output   ONLY `key=value` lines, safe to append to $GITHUB_OUTPUT
+#
+# They used to be mixed on stdout, and .github/workflows/coverage.yml appended
+# every line with `while IFS='=' read -r key value`, so prose such as
+# "Summary of coverage by layer" became a step-output key. See issue #39.
+GITHUB_OUTPUT_MODE=0
+LCOV_FILE=""
+for arg in "$@"; do
+  case "$arg" in
+    --github-output) GITHUB_OUTPUT_MODE=1 ;;
+    -h|--help) sed -n '2,4p' "$0"; exit 0 ;;
+    *) LCOV_FILE="$arg" ;;
+  esac
+done
+LCOV_FILE="${LCOV_FILE:-coverage/lcov.info}"
 
 if [ ! -f "$LCOV_FILE" ]; then
   echo "Error: lcov file not found at $LCOV_FILE" >&2
@@ -70,24 +86,23 @@ DATA_COV=$(calculate_layer_coverage "/features/.*/data/")
 PRESENTATION_COV=$(calculate_layer_coverage "/features/.*/presentation/")
 CORE_COV=$(calculate_layer_coverage "/core/")
 
-# Output values with % suffix for display
-echo "Output values with % suffix for display"
-echo "domain_display=$DOMAIN_COV%"
-echo "data_display=$DATA_COV%"
-echo "presentation_display=$PRESENTATION_COV%"
-echo "core_display=$CORE_COV%"
+if [ "$GITHUB_OUTPUT_MODE" -eq 1 ]; then
+  # Machine-readable only. Every line here MUST be a valid key=value pair.
+  echo "domain=$DOMAIN_COV"
+  echo "data=$DATA_COV"
+  echo "presentation=$PRESENTATION_COV"
+  echo "core=$CORE_COV"
+  echo "domain_display=$DOMAIN_COV%"
+  echo "data_display=$DATA_COV%"
+  echo "presentation_display=$PRESENTATION_COV%"
+  echo "core_display=$CORE_COV%"
+  exit 0
+fi
 
-# Output numeric values for comparison
-echo "Output numeric values for comparison"
-echo "domain=$DOMAIN_COV"
-echo "data=$DATA_COV"
-echo "presentation=$PRESENTATION_COV"
-echo "core=$CORE_COV"
-
-# Print to console for visibility
-echo "Summary of coverage by layer"
-echo "Domain Layer: ${DOMAIN_COV}%"
-echo "Data Layer: ${DATA_COV}%"
-echo "Presentation Layer: ${PRESENTATION_COV}%"
-echo "Core Layer: ${CORE_COV}%"
+# Human summary. These are line-coverage percentages, not file counts.
+echo "Coverage by layer (percentage of executable lines covered):"
+echo "  Domain:       ${DOMAIN_COV}%"
+echo "  Data:         ${DATA_COV}%"
+echo "  Presentation: ${PRESENTATION_COV}%"
+echo "  Core:         ${CORE_COV}%"
 


### PR DESCRIPTION
Two pieces of confusion in the coverage workflow. One of them cost a bogus issue,
which is why it is worth removing rather than tolerating.

## 1. File counts printed as if they were coverage

```
📊 Coverage Metrics:
  Overall: 89.8%
  Domain files: 15
```

`15` is a count of `SF:` records, sitting directly beneath a real percentage
under a heading saying "Coverage Metrics". I read that block, concluded the
per-layer thresholds were unenforced, and filed #25 on it. They were enforced all
along — by a **different** step (`layer_coverage`). #25 is closed as invalid.

Now the counts are labelled as counts and point at the step that reports real
percentages:

```
📊 Overall line coverage: 89.8%

Source files measured per layer (counts, not coverage):
  domain: 15   data: 12   presentation: 11   core: 70
Per-layer coverage percentages are reported by the
'Calculate coverage by layer (architecture gates)' step above.
```

## 2. Prose was being written into `$GITHUB_OUTPUT`

`calculate_layer_coverage.sh` mixed labels and `key=value` on stdout, and the
workflow appended **every** line via `while IFS='=' read -r key value`. So
`Summary of coverage by layer` became a step-output key with an empty value.

The script now has two explicit modes:

```bash
./scripts/test/calculate_layer_coverage.sh                  # human summary
./scripts/test/calculate_layer_coverage.sh --github-output  # ONLY key=value
```

Verified locally against real `lcov.info` — `--github-output` emits eight
`key=value` lines and nothing else, and no emitted key contains a space:

```
domain=100.0  data=96.2  presentation=93.5  core=85.2
domain_display=100.0%  ...
```

The workflow uses `--github-output` for `$GITHUB_OUTPUT` and the human mode for
log readability.

## Docs corrected

`docs/guides/testing/test-coverage.md` described output the script has never
produced: per-file low-coverage listings and a `Shared` layer. There are four
layers and no per-file output. Since this PR changes that output, its description
had to follow.

## Not touched

The `Enforce coverage thresholds` step. It still gates on the same five numbers
(overall 80, domain 100, data 90, presentation 80, core 80). Criterion 5 asks for
a dispatched run proving it still passes — reported on the issue.

Refs koniz-dev/flutter-starter#39